### PR TITLE
Updated the README.md with the contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,9 @@ There are many ways to join the sktime community. We follow the [all-contributor
 * **clean, descriptive specification syntax** -- based on modern object-oriented design principles for data science.
 * **fair model assessment and benchmarking** -- build your models, inspect your models, check your models, avoid pitfalls.
 * **easily extensible** -- easy extension templates to add your own algorithms compatible with sktime's API.
+
+## :star2: Contributors
+
+<a href="https://github.com/sktime/sktime/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=sktime/sktime" />
+</a>


### PR DESCRIPTION
#Description

Adding a separate section for contributors in the readme file. I just found a way to do this efficiently. Instead of marking down all the names, the idea is to use the services from https://contrib.rocks/preview.

##Issue reference
#3717

## Screenshot of the fix

![image](https://user-images.githubusercontent.com/69035013/210374995-6d8f0942-3b07-4863-881d-0bb5d9a8bf92.png)

## Additional Comments

Clicking the image will redirect you here https://github.com/sktime/sktime/graphs/contributors
And, hovering on the profile image will give you the name of the contributor. 

